### PR TITLE
[ADD] History API fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "eslint": "eslint src",
     "client-dist": "NODE_ENV=production webpack --progress --colors",
-    "client-dev": "webpack-dev-server --colors --hot --inline --host 0.0.0.0 --port 8080",
+    "client-dev": "webpack-dev-server --history-api-fallback --colors --hot --inline --host 0.0.0.0 --port 8080",
     "srv-dev": "DEBUG=tetris:* babel-watch -w src src/server/main.js",
     "srv-dist": "DEBUG=tetris:* babel src --out-dir dist",
     "test": "mocha --require babel-core/register --reporter spec",


### PR DESCRIPTION
This would allow ease of project extension with a real world UI:
- homepage
- ranking page
- new game page
- join game page
- etc.
Documentation about historyApiFallback wasn't that easy to find and I think it would be great to have this here by default.
It doesn't break anything at all.

This is a reaction to a react-router-redux issue in which a contributor was explaining that react-router had no plan to support hash routing.
I'm therefore breaking the project rules by not respecting the hash routing requirements for rooms, but I think it is not a great idea to enforce new web developers to learn such an old practice as it was in first place just a trick to make SPAs work on very old IEs.

Hope you will read this, this project you brought to 42's school really is cool, thanks RedPelicans' team for this.

lgosse@student.42.fr